### PR TITLE
Tonymessagecount

### DIFF
--- a/app/controllers/MessageController.php
+++ b/app/controllers/MessageController.php
@@ -109,16 +109,12 @@
         $messages = array_reverse(iterator_to_array($MMessage->findByParticipant($_SESSION['_id']->{'$id'})));
 
         $replies = array();
-        $unread = 0;
+        $unread = $MMessage->getNumUnread($_SESSION['_id']->{'$id'});
         foreach ($messages as $m) {
           $reply = array_pop($m['replies']);
           $reply['_id'] = $m['_id'];
 
           $from = $reply['from'];
-          if (!$reply['read']) {
-            $reply['read'] = (strcmp($from, $_SESSION['_id']) == 0);
-          }
-          if (!$reply['read']) $unread ++;
 
           $c->setFromNamePic($reply, $from);
 
@@ -187,8 +183,12 @@
         // Set replies to read
         $repliesn = count($entry['replies']);
         for ($i = 0; $i < $repliesn; $i ++) {
-          if (strcmp($entry['replies'][$i]['from'], $_SESSION['_id']) != 0)
+          if (strcmp($entry['replies'][$i]['from'], $_SESSION['_id']) != 0) {
+            if (!$entry['replies'][$i]['read']) {
+              $MMessage->decrementUnread($_SESSION['_id']->{'$id'});
+            }
             $entry['replies'][$i]['read'] = true;
+          }
         }
         $MMessage->save($entry);
 

--- a/app/controllers/MessageController.php
+++ b/app/controllers/MessageController.php
@@ -109,7 +109,7 @@
         $messages = array_reverse(iterator_to_array($MMessage->findByParticipant($_SESSION['_id']->{'$id'})));
 
         $replies = array();
-        $unread = $MMessage->getNumUnread($_SESSION['_id']->{'$id'});
+        $unread = $MMessage->getNumUnread($_SESSION['_id']);
         foreach ($messages as $m) {
           $reply = array_pop($m['replies']);
           $reply['_id'] = $m['_id'];
@@ -185,7 +185,7 @@
         for ($i = 0; $i < $repliesn; $i ++) {
           if (strcmp($entry['replies'][$i]['from'], $_SESSION['_id']) != 0) {
             if (!$entry['replies'][$i]['read']) {
-              $MMessage->decrementUnread($_SESSION['_id']->{'$id'});
+              $MMessage->decrementUnread($_SESSION['_id']);
             }
             $entry['replies'][$i]['read'] = true;
           }

--- a/app/controllers/MigrationsController.php
+++ b/app/controllers/MigrationsController.php
@@ -6,13 +6,13 @@
       global $MApp;
 
       // Get current counter
-      $mlast = AppModel::getByStringId('migrations');
+      $mlast = -1;
       if ($mlast == NULL) $mlast = 0;
       else $mlast = $mlast['current'];
 
       // Do migrations after counter
       $mcur = $mlast;
-      $migrations = glob($GLOBALS['dirpre'].'migrations/*.php');
+      $migrations = glob($GLOBALS['dirpre'].'migrations/20.php');
       natsort($migrations);
       foreach ($migrations as $m) {
         if (($mcur = str2int($m)) > $mlast) {

--- a/app/controllers/MigrationsController.php
+++ b/app/controllers/MigrationsController.php
@@ -6,13 +6,13 @@
       global $MApp;
 
       // Get current counter
-      $mlast = -1;
+      $mlast = AppModel::getByStringId('migrations');
       if ($mlast == NULL) $mlast = 0;
       else $mlast = $mlast['current'];
 
       // Do migrations after counter
       $mcur = $mlast;
-      $migrations = glob($GLOBALS['dirpre'].'migrations/20.php');
+      $migrations = glob($GLOBALS['dirpre'].'migrations/*.php');
       natsort($migrations);
       foreach ($migrations as $m) {
         if (($mcur = str2int($m)) > $mlast) {

--- a/app/migrations/20.php
+++ b/app/migrations/20.php
@@ -1,0 +1,40 @@
+<?php
+  function countUnread($id) {
+    global $MMessage;
+    $messages = array_reverse(iterator_to_array(
+        $MMessage->findByParticipant($id->{'$id'})));
+    $unread = 0;
+    foreach ($messages as $m) {
+      $reply = array_pop($m['replies']);
+      $reply['_id'] = $m['_id'];
+
+      $from = $reply['from'];
+      if (!$reply['read']) {
+        $reply['read'] = (strcmp($from, $id) == 0);
+      }
+      if (!$reply['read']) $unread++;
+    }
+    return $unread;
+  }
+
+  global $MStudent;
+
+  $students = $MStudent->getAll();
+
+  foreach ($students as $student) {
+    if (!isset($student['unread'])) {
+      $studentId = $student['_id'];
+      $student['unread'] = countUnread($studentId);
+    }
+    $MStudent->save($student);
+  }
+
+  $recruiters = RecruiterModel::getAll();
+
+  foreach ($recruiters as $recruiter) {
+    if (!isset($recruiter['unread'])) {
+      $recruiterId = $recruiter['_id'];
+      RecruiterModel::setUnread($recruiterId, countUnread($recruiterId));
+    }
+  }
+?>

--- a/app/migrations/20.php
+++ b/app/migrations/20.php
@@ -1,8 +1,7 @@
 <?php
   function countUnread($id) {
-    global $MMessage;
     $messages = array_reverse(iterator_to_array(
-        $MMessage->findByParticipant($id->{'$id'})));
+        MessageModel::findByParticipant($id->{'$id'})));
     $unread = 0;
     foreach ($messages as $m) {
       $reply = array_pop($m['replies']);
@@ -17,16 +16,14 @@
     return $unread;
   }
 
-  global $MStudent;
-
-  $students = $MStudent->getAll();
+  $students = StudentModel::getAll();
 
   foreach ($students as $student) {
     if (!isset($student['unread'])) {
       $studentId = $student['_id'];
       $student['unread'] = countUnread($studentId);
+      StudentModel::save($student);
     }
-    $MStudent->save($student);
   }
 
   $recruiters = RecruiterModel::getAll();

--- a/app/models/MessageModel.php
+++ b/app/models/MessageModel.php
@@ -28,7 +28,7 @@
       ));
       foreach ($entry['participants'] as $participant) {
         if ($participant != $from) {
-          $this->incrementUnread($participant);
+          $this->incrementUnread(new MongoId($participant));
         }
       }
       self::$collection->save($entry);
@@ -55,34 +55,33 @@
       return ($this->get($id) !== NULL);
     }
 
-    function getNumUnread($studentOrRecruiterId) {
+    function getNumUnread(MongoId $studentOrRecruiterId) {
       if (StudentModel::exists($studentOrRecruiterId)) {
-        return StudentModel::getNumUnread(new MongoId($studentOrRecruiterId));
+        return StudentModel::getNumUnread($studentOrRecruiterId);
       } else if (RecruiterModel::IDexists($studentOrRecruiterId)) {
-        return RecruiterModel::getNumUnread(new MongoId($studentOrRecruiterId));
+        return RecruiterModel::getNumUnread($studentOrRecruiterId);
       } else {
-        // This shouldn't happen!
-        return -1;
+        invariant(false, 'Invalid student or recruiter');
       }
     }
 
-    function incrementUnread($studentOrRecruiterId) {
+    function incrementUnread(MongoId $studentOrRecruiterId) {
       if (StudentModel::exists($studentOrRecruiterId)) {
-        StudentModel::incrementUnread(new MongoId($studentOrRecruiterId));
+        StudentModel::incrementUnread($studentOrRecruiterId);
       } else if (RecruiterModel::IDexists($studentOrRecruiterId)) {
-        RecruiterModel::incrementUnread(new MongoId($studentOrRecruiterId));
+        RecruiterModel::incrementUnread($studentOrRecruiterId);
       } else {
-        // This shouldn't happen!
+        invariant(false, 'Invalid student or recruiter');
       }
     }
 
-    function decrementUnread($studentOrRecruiterId) {
+    function decrementUnread(MongoId $studentOrRecruiterId) {
       if (StudentModel::exists($studentOrRecruiterId)) {
-        StudentModel::decrementUnread(new MongoId($studentOrRecruiterId));
+        StudentModel::decrementUnread($studentOrRecruiterId);
       } else if (RecruiterModel::IDexists($studentOrRecruiterId)) {
-        RecruiterModel::decrementUnread(new MongoId($studentOrRecruiterId));
+        RecruiterModel::decrementUnread($studentOrRecruiterId);
       } else {
-        // This shouldn't happen!
+        invariant(false, 'Invalid student or recruiter');
       }
     }
 

--- a/app/models/MessageModel.php
+++ b/app/models/MessageModel.php
@@ -26,6 +26,11 @@
       array_push($entry['replies'], array(
         'from' => $from, 'msg' => $msg, 'time' => time(), 'read' => false
       ));
+      foreach ($entry['participants'] as $participant) {
+        if ($participant != $from) {
+          $this->incrementUnread($participant);
+        }
+      }
       self::$collection->save($entry);
       return $entry;
     }
@@ -48,6 +53,37 @@
 
     function exists($id) {
       return ($this->get($id) !== NULL);
+    }
+
+    function getNumUnread($studentOrRecruiterId) {
+      if (StudentModel::exists($studentOrRecruiterId)) {
+        return StudentModel::getNumUnread(new MongoId($studentOrRecruiterId));
+      } else if (RecruiterModel::IDexists($studentOrRecruiterId)) {
+        return RecruiterModel::getNumUnread(new MongoId($studentOrRecruiterId));
+      } else {
+        // This shouldn't happen!
+        return -1;
+      }
+    }
+
+    function incrementUnread($studentOrRecruiterId) {
+      if (StudentModel::exists($studentOrRecruiterId)) {
+        StudentModel::incrementUnread(new MongoId($studentOrRecruiterId));
+      } else if (RecruiterModel::IDexists($studentOrRecruiterId)) {
+        RecruiterModel::incrementUnread(new MongoId($studentOrRecruiterId));
+      } else {
+        // This shouldn't happen!
+      }
+    }
+
+    function decrementUnread($studentOrRecruiterId) {
+      if (StudentModel::exists($studentOrRecruiterId)) {
+        StudentModel::decrementUnread(new MongoId($studentOrRecruiterId));
+      } else if (RecruiterModel::IDexists($studentOrRecruiterId)) {
+        RecruiterModel::decrementUnread(new MongoId($studentOrRecruiterId));
+      } else {
+        // This shouldn't happen!
+      }
     }
 
     protected static $collection;

--- a/app/models/RecruiterModel.php
+++ b/app/models/RecruiterModel.php
@@ -2,6 +2,11 @@
   require_once($GLOBALS['dirpre'].'models/Model.php');
 
   interface RecruiterModelInterface {
+    public static function getNumUnread(MongoId $recruiterId);
+    public static function setUnread(MongoId $recruiterId, $count);
+    public static function incrementUnread(MongoId $recruiterId);
+    public static function decrementUnread(MongoId $recruiterId);
+
     public static function getCredits(MongoId $recruiterId);
     public static function setCredits(MongoId $recruiterId, $count);
     public static function addCredits(MongoId $recruiterId, $count);
@@ -34,6 +39,31 @@
 
     const CREDITS_FOR_COMPANYPROFILE = 1;
     const CREDITS_FOR_JOB            = 1;
+
+    public static function getNumUnread(MongoId $recruiterId) {
+      $query = (new DBQuery(self::$collection))
+        ->queryForId($recruiterId)->projectField('unread');
+      $recruiter = $query->findOne();
+      return $recruiter['unread'];
+    }
+
+    public static function setUnread(MongoId $recruiterId, $count) {
+      $update = (new DBUpdateQuery(self::$collection))
+        ->queryForId($recruiterId)->toUpdate('unread', $count);
+      $update->run();
+    }
+
+    public static function incrementUnread(MongoId $recruiterId) {
+      $update = (new DBUpdateQuery(self::$collection))
+        ->queryForId($recruiterId)->toAdd('unread', 1);
+      $update->run();
+    }
+
+    public static function decrementUnread(MongoId $recruiterId) {
+      $update = (new DBUpdateQuery(self::$collection))
+        ->queryForId($recruiterId)->toAdd('unread', -1);
+      $update->run();
+    }
 
     public static function getCredits(MongoId $recruiterId) {
       $query = (new DBQuery(self::$collection))

--- a/app/models/StudentModel.php
+++ b/app/models/StudentModel.php
@@ -8,6 +8,11 @@
     public static function getProfile(MongoId $studentId);
     public static function setProfile(MongoId $studentId, array $profileData);
 
+    public static function getNumUnread(MongoId $studentId);
+    public static function setUnread(MongoId $studentId, $count);
+    public static function incrementUnread(MongoId $studentId);
+    public static function decrementUnread(MongoId $studentId);
+
     /**
      * Retrieves just email, name, and school name.
      */
@@ -49,6 +54,31 @@
       $student = self::getById($studentId, ['email' => true, 'name' => true]);
       $student['school'] = $S->nameOf($student['email']);
       return $student;
+    }
+
+    public static function getNumUnread(MongoId $studentId) {
+      $query = (new DBQuery(self::$collection))
+        ->queryForId($studentId)->projectField('unread');
+      $student = $query->findOne();
+      return $student['unread'];
+    }
+
+    public static function setUnread(MongoId $studentId, $count) {
+      $update = (new DBUpdateQuery(self::$collection))
+        ->queryForId($studentId)->toUpdate('unread', $count);
+      $update->run();
+    }
+
+    public static function incrementUnread(MongoId $studentId) {
+      $update = (new DBUpdateQuery(self::$collection))
+        ->queryForId($studentId)->toAdd('unread', 1);
+      $update->run();
+    }
+
+    public static function decrementUnread(MongoId $studentId) {
+      $update = (new DBUpdateQuery(self::$collection))
+        ->queryForId($studentId)->toAdd('unread', -1);
+      $update->run();
     }
 
     public function __construct() {

--- a/app/views/navbar.php
+++ b/app/views/navbar.php
@@ -49,7 +49,7 @@
     color: #ffd800;
   }
 
-  .messagecount {
+  .highlight {
     color: #ffd800;
   }
 </style>
@@ -113,7 +113,7 @@
           global $MMessage;
           $num = $MMessage->getNumUnread($_SESSION['_id']->{'$id'});
           if ($num > 0) {
-            echo "<a href=\"$link\"><opt>$text <span class=\"messagecount\">($num)</span></opt></a>";
+            echo "<a href=\"$link\"><opt>$text <span class=\"highlight\">($num)</span></opt></a>";
           } else {
             echo "<a href=\"$link\"><opt>$text (0)</span></opt></a>";
           }

--- a/app/views/navbar.php
+++ b/app/views/navbar.php
@@ -48,6 +48,10 @@
   opt:hover {
     color: #ffd800;
   }
+
+  .messagecount {
+    color: #ffd800;
+  }
 </style>
 <?php
   $curdir = dirname($_SERVER['REQUEST_URI'] . '/.');
@@ -105,8 +109,17 @@
         $text = $opt[0];
         $link = $opt[1];
         if (!$states[$opt[2]]) continue;
-
-        echo "<a href=\"$link\"><opt>$text</opt></a>";
+        if ($opt[0] == "Messages") {
+          global $MMessage;
+          $num = $MMessage->getNumUnread($_SESSION['_id']->{'$id'});
+          if ($num > 0) {
+            echo "<a href=\"$link\"><opt>$text <span class=\"messagecount\">($num)</span></opt></a>";
+          } else {
+            echo "<a href=\"$link\"><opt>$text (0)</span></opt></a>";
+          }
+        } else {
+          echo "<a href=\"$link\"><opt>$text</opt></a>";
+        }
       }
     ?>
   </options>

--- a/app/views/navbar.php
+++ b/app/views/navbar.php
@@ -110,8 +110,7 @@
         $link = $opt[1];
         if (!$states[$opt[2]]) continue;
         if ($opt[0] == "Messages") {
-          global $MMessage;
-          $num = $MMessage->getNumUnread($_SESSION['_id']->{'$id'});
+          $num = MessageModel::getNumUnread($_SESSION['_id']);
           if ($num > 0) {
             echo "<a href=\"$link\"><opt>$text <span class=\"highlight\">($num)</span></opt></a>";
           } else {


### PR DESCRIPTION
I added an "unread" field to the recruiter and student collections, which gets incremented/decremented when someone gets a new message/reads a message. This is so that getting the number of unread messages only requires a simple look-up of a field.

Migration 20 (in this commit) should be run on the server if we adapt these changes.

Suggestions/nits/corrections very welcome! The "// This shouldn't happen!" lines could probably be improved. I also probably didn't follow the MVC code-separation very well (students and recruiters being in different collections made things a little messy).